### PR TITLE
Add skeleton _app and _sup modules

### DIFF
--- a/src/leveled_app.erl
+++ b/src/leveled_app.erl
@@ -1,0 +1,16 @@
+-module(leveled_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    leveled_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/leveled_sup.erl
+++ b/src/leveled_sup.erl
@@ -1,0 +1,23 @@
+-module(leveled_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+init([]) ->
+    {ok, { {one_for_one, 5, 10}, []} }.


### PR DESCRIPTION
Given that leveled has a `mod` attribute, and thus should be runnable as an OTP application, a few modules were missing.